### PR TITLE
fix(blockssupport): slack message blocks are supported now

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const Plugin = require("release-it").Plugin;
 const Promise = require("es6-promise").Promise;
-const Slack = require("slack-node");
+const { IncomingWebhook } = require("@slack/webhook");
 const slackifyMarkdown = require("slackify-markdown");
 const fs = require("fs");
 const path = require("path");
@@ -115,15 +115,16 @@ class SlackNotify extends Plugin {
         reject(new Error("Slack request timed out"));
       }, TIMEOUT);
 
-      const slack = new Slack();
-      slack.setWebhook(webHookUrl);
-      slack.webhook(payload, err => {
-        clearTimeout(timeout);
-        if (err) {
-          return reject(err);
-        }
-        return resolve();
-      });
+      const webhook = new IncomingWebhook(webHookUrl);
+      webhook
+        .send(payload)
+        .then(function(result) {
+          resolve(result);
+        })
+        .catch(function(err) {
+          throw new Error(err);
+          reject(err);
+        });
     });
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -843,6 +843,21 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
     },
+    "@slack/types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-uak4Jbi8nlX8xmElkPt1ixxVQXMKdBRbzBayn5bRzZ9Yx3bQGlyJdFs6GjEKI+fvFP0ZTiGWKOzlJTH3Tm/9fg=="
+    },
+    "@slack/webhook": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@slack/webhook/-/webhook-5.0.1.tgz",
+      "integrity": "sha512-cTp0xOdd28gbMAGR80IzcG2QtwDPO0oq7NopxbitCUiDYVC40r7syJB86MBkt9spABOl1uNjB26tA9Lhe3XBbQ==",
+      "requires": {
+        "@slack/types": "^1.1.0",
+        "@types/node": ">=8.9.0",
+        "axios": "^0.18.0"
+      }
+    },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -1110,6 +1125,15 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+    },
+    "axios": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+      "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      }
     },
     "babel-polyfill": {
       "version": "6.26.0",
@@ -2790,6 +2814,29 @@
       "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
       "requires": {
         "is-buffer": "~2.0.3"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "for-in": {
@@ -8770,17 +8817,6 @@
         }
       }
     },
-    "requestretry": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/requestretry/-/requestretry-1.13.0.tgz",
-      "integrity": "sha512-Lmh9qMvnQXADGAQxsXHP4rbgO6pffCfuR8XUBdP9aitJcLQJxhp7YZK4xAVYXnPJ5E52mwrfiKQtKonPL8xsmg==",
-      "requires": {
-        "extend": "^3.0.0",
-        "lodash": "^4.15.0",
-        "request": "^2.74.0",
-        "when": "^3.7.7"
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -9141,14 +9177,6 @@
             "escape-string-regexp": "^1.0.5"
           }
         }
-      }
-    },
-    "slack-node": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/slack-node/-/slack-node-0.1.8.tgz",
-      "integrity": "sha1-zamN6GgUhbMB3GdC3cOJcRf600k=",
-      "requires": {
-        "requestretry": "^1.2.2"
       }
     },
     "slackify-markdown": {
@@ -10302,11 +10330,6 @@
       "requires": {
         "defaults": "^1.0.3"
       }
-    },
-    "when": {
-      "version": "3.7.8",
-      "resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
-      "integrity": "sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
   },
   "homepage": "https://github.com/mjangir/release-it-slack-bot#readme",
   "dependencies": {
+    "@slack/webhook": "^5.0.1",
     "es6-promise": "^4.2.8",
     "lodash": "^4.17.15",
     "release-it": "^12.3.6",
     "request": "^2.88.0",
-    "slack-node": "^0.1.8",
     "slackify-markdown": "^1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Changed the core package from slack-node to official slack-node-sdk because the older one was not
supporting block messages in slack.